### PR TITLE
Update sysinfo to `v0.26.6`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ description = "System metric export through Opentelemetry"
 
 [dependencies]
 opentelemetry = { version="0.17.0", features = ["rt-tokio", "metrics"] }
-sysinfo = "0.24.5"
+sysinfo = "0.26.6"
 indexmap = "1.8"


### PR DESCRIPTION
Updates the internal `ntapi` dependency to v0.4 to fix the future incompatibility warning:

> the following packages contain code that will be rejected by a future version of Rust: ntapi v0.3.7